### PR TITLE
Mobile Release v1.51.0

### DIFF
--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -15,6 +15,9 @@ import {
 } from '@wordpress/block-editor';
 import { BlockQuotation } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
+import { Platform } from '@wordpress/element';
+
+const isWebPlatform = Platform.OS === 'web';
 
 export default function QuoteEdit( {
 	attributes,
@@ -82,7 +85,7 @@ export default function QuoteEdit( {
 				{ ( ! RichText.isEmpty( citation ) || isSelected ) && (
 					<RichText
 						identifier="citation"
-						tagName="cite"
+						tagName={ isWebPlatform ? 'cite' : undefined }
 						style={ { display: 'block' } }
 						value={ citation }
 						onChange={ ( nextCitation ) =>

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.js
@@ -188,7 +188,9 @@ class BottomSheetRangeCell extends Component {
 							this.a11yDecrementValue();
 							break;
 						case 'activate':
-							openUnitPicker();
+							if ( openUnitPicker ) {
+								openUnitPicker();
+							}
 							break;
 					}
 				} }

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.js
@@ -160,7 +160,7 @@ class BottomSheetRangeCell extends Component {
 				__( '%1$s. %2$s is %3$s %4$s.' ),
 				cellProps.label,
 				settingLabel,
-				value,
+				toFixed( value, decimalNum ),
 				unitLabel
 			);
 		};

--- a/packages/components/src/mobile/bottom-sheet/test/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/test/range-cell.native.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { AccessibilityInfo } from 'react-native';
+import { create, act } from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import RangeCell from '../range-cell';
+
+// Avoid errors due to mocked stylesheet files missing required selectors
+jest.mock( '@wordpress/compose', () => ( {
+	...jest.requireActual( '@wordpress/compose' ),
+	withPreferredColorScheme: jest.fn( ( Component ) => ( props ) => (
+		<Component
+			{ ...props }
+			preferredColorScheme={ {} }
+			getStylesFromColorScheme={ jest.fn( () => ( {} ) ) }
+		/>
+	) ),
+} ) );
+
+const isScreenReaderEnabled = Promise.resolve( true );
+beforeAll( () => {
+	// Mock async native module to avoid act warning
+	AccessibilityInfo.isScreenReaderEnabled = jest.fn(
+		() => isScreenReaderEnabled
+	);
+} );
+
+it( 'allows modifying units via a11y actions', async () => {
+	const mockOpenUnitPicker = jest.fn();
+	const renderer = create(
+		<RangeCell
+			label="Opacity"
+			minimumValue={ 0 }
+			maximumValue={ 100 }
+			value={ 50 }
+			onChange={ jest.fn() }
+			openUnitPicker={ mockOpenUnitPicker }
+		/>
+	);
+	// Await async update to component state to avoid act warning
+	await act( () => isScreenReaderEnabled );
+	const { onAccessibilityAction } = renderer.toJSON().props;
+
+	onAccessibilityAction( { nativeEvent: { actionName: 'activate' } } );
+	expect( mockOpenUnitPicker ).toHaveBeenCalled();
+} );
+
+describe( 'when range lacks an adjustable unit', () => {
+	it( 'disallows modifying units via a11y actions', async () => {
+		const renderer = create(
+			<RangeCell
+				label="Opacity"
+				minimumValue={ 0 }
+				maximumValue={ 100 }
+				value={ 50 }
+				onChange={ jest.fn() }
+			/>
+		);
+		// Await async update to component state to avoid act warning
+		await act( () => isScreenReaderEnabled );
+		const { onAccessibilityAction } = renderer.toJSON().props;
+
+		expect( () =>
+			onAccessibilityAction( { nativeEvent: { actionName: 'activate' } } )
+		).not.toThrow();
+	} );
+} );

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Passing a tuple of components with `as` prop to `ActionItem.Slot` component is no longer supported. Please pass a component with `as` prop instead ([#30417](https://github.com/WordPress/gutenberg/pull/30417)).
+
 ## 1.1.0 (2021-03-17)
 
 ### Deprecations

--- a/packages/interface/src/components/action-item/index.js
+++ b/packages/interface/src/components/action-item/index.js
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { isArray, isEmpty, noop } from 'lodash';
+import { isEmpty, noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { ButtonGroup, Button, Slot, Fill } from '@wordpress/components';
-import deprecated from '@wordpress/deprecated';
 import { Children } from '@wordpress/element';
 
 function ActionItemSlot( {
@@ -17,18 +16,6 @@ function ActionItemSlot( {
 	bubblesVirtually,
 	...props
 } ) {
-	if ( isArray( Component ) ) {
-		deprecated(
-			'Passing a tuple of components with `as` prop to `ActionItem.Slot` component',
-			{
-				since: '10.2',
-				plugin: 'Gutenberg',
-				alternative: 'a component with `as` prop',
-				version: '10.3',
-			}
-		);
-		Component = Component[ 0 ];
-	}
 	return (
 		<Slot
 			name={ name }

--- a/packages/react-native-aztec/package.json
+++ b/packages/react-native-aztec/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-aztec",
-	"version": "1.50.0",
+	"version": "1.50.1",
 	"description": "Aztec view for react-native.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-aztec/package.json
+++ b/packages/react-native-aztec/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-aztec",
-	"version": "1.49.0",
+	"version": "1.50.0",
 	"description": "Aztec view for react-native.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-aztec/package.json
+++ b/packages/react-native-aztec/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-aztec",
-	"version": "1.50.1",
+	"version": "1.51.0",
 	"description": "Aztec view for react-native.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-bridge/android/react-native-bridge/build.gradle
+++ b/packages/react-native-bridge/android/react-native-bridge/build.gradle
@@ -59,7 +59,7 @@ android {
             // Despite being in a folder called "resources", the files in
             // unsupported-block-editor are accessed as assets by their
             // consumers: the WordPressEditor library.
-            assets.srcDirs += '../../../../resources/unsupported-block-editor'
+            assets.srcDirs += '../../../../../resources/unsupported-block-editor'
         }
     }
 }

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/assets/gutenberg-web-single-block
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/assets/gutenberg-web-single-block
@@ -1,1 +1,1 @@
-../../../../common/gutenberg-web-single-block
+../../../../../common/gutenberg-web-single-block

--- a/packages/react-native-bridge/package.json
+++ b/packages/react-native-bridge/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-bridge",
-	"version": "1.50.1",
+	"version": "1.51.0",
 	"description": "Native bridge library used to integrate the block editor into a native App.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-bridge/package.json
+++ b/packages/react-native-bridge/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-bridge",
-	"version": "1.50.0",
+	"version": "1.50.1",
 	"description": "Native bridge library used to integrate the block editor into a native App.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-bridge/package.json
+++ b/packages/react-native-bridge/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-bridge",
-	"version": "1.49.0",
+	"version": "1.50.0",
 	"description": "Native bridge library used to integrate the block editor into a native App.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,8 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 
+## 1.50.0
+
 -   [***] a11y: Screenreader improvements for the UnitControl component [#29741]
 
 ## 1.49.0

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,13 +11,20 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 
+## 1.50.1
+
+-   [x] Truncate rangecell screenreader decimals] [#30678]
+-   [x] Fix Quote block citation [#30548]
+-   [xx] Fix crash from non-adjustable unit RangeCell a11y activation [#30636]
+-   [xx] Fix Unsupported Block Editor on Android [#30650]
+
 ## 1.50.0
 
 -   [***] a11y: Screenreader improvements for the UnitControl component [#29741]
 
 ## 1.49.0
 
-* [*] Remove the cancel button from settings options (Android only) [https://github.com/WordPress/gutenberg/pull/29599]
+-   [*] Remove the cancel button from settings options (Android only) [https://github.com/WordPress/gutenberg/pull/29599]
 
 ## 1.48.0
 

--- a/packages/react-native-editor/ios/Gemfile.lock
+++ b/packages/react-native-editor/ios/Gemfile.lock
@@ -1,4 +1,7 @@
 GEM
+  specs:
+
+GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.1)
@@ -80,4 +83,4 @@ DEPENDENCIES
   cocoapods (~> 1.8.0)!
 
 BUNDLED WITH
-   2.0.2
+   2.2.10

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - Gutenberg (1.50.1):
+  - Gutenberg (1.51.0):
     - React-Core (= 0.61.5)
     - React-CoreModules (= 0.61.5)
     - React-RCTImage (= 0.61.5)
@@ -253,7 +253,7 @@ PODS:
     - React-Core
   - RNSVG (9.13.6-gb):
     - React-Core
-  - RNTAztecView (1.50.1):
+  - RNTAztecView (1.51.0):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.4)
   - WordPress-Aztec-iOS (1.19.4)
@@ -402,7 +402,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 118d0d177724c2d67f08a59136eb29ef5943ec75
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  Gutenberg: 62fc73dafa850e4e5ae259d36503f5ab9cb4799b
+  Gutenberg: 74ef5f17bcd712fd31f4c7a666ff1ccd2c871c68
   RCTRequired: b153add4da6e7dbc44aebf93f3cf4fcae392ddf1
   RCTTypeSafety: 9aa1b91d7f9310fc6eadc3cf95126ffe818af320
   React: b6a59ef847b2b40bb6e0180a97d0ca716969ac78
@@ -435,7 +435,7 @@ SPEC CHECKSUMS:
   RNReanimated: f05baf4cd76b6eab2e4d7e2b244424960b968918
   RNScreens: 953633729a42e23ad0c93574d676b361e3335e8b
   RNSVG: 46c4b680fe18237fa01eb7d7b311d77618fde31f
-  RNTAztecView: f33408723146b0ea91645f0730efd69e26031a9d
+  RNTAztecView: af275654e1326cd8c0678c92aa16b860194155d5
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b
 

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - Gutenberg (1.50.0):
+  - Gutenberg (1.50.1):
     - React-Core (= 0.61.5)
     - React-CoreModules (= 0.61.5)
     - React-RCTImage (= 0.61.5)
@@ -253,7 +253,7 @@ PODS:
     - React-Core
   - RNSVG (9.13.6-gb):
     - React-Core
-  - RNTAztecView (1.50.0):
+  - RNTAztecView (1.50.1):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.4)
   - WordPress-Aztec-iOS (1.19.4)
@@ -402,7 +402,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 118d0d177724c2d67f08a59136eb29ef5943ec75
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  Gutenberg: 3fb0791ec50a4bfb82d53ee47d57b413229d3a97
+  Gutenberg: 62fc73dafa850e4e5ae259d36503f5ab9cb4799b
   RCTRequired: b153add4da6e7dbc44aebf93f3cf4fcae392ddf1
   RCTTypeSafety: 9aa1b91d7f9310fc6eadc3cf95126ffe818af320
   React: b6a59ef847b2b40bb6e0180a97d0ca716969ac78
@@ -435,7 +435,7 @@ SPEC CHECKSUMS:
   RNReanimated: f05baf4cd76b6eab2e4d7e2b244424960b968918
   RNScreens: 953633729a42e23ad0c93574d676b361e3335e8b
   RNSVG: 46c4b680fe18237fa01eb7d7b311d77618fde31f
-  RNTAztecView: 7552d3a49d7958b422dc089ae5e1d91b8300f58d
+  RNTAztecView: f33408723146b0ea91645f0730efd69e26031a9d
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b
 

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - Gutenberg (1.49.0):
+  - Gutenberg (1.50.0):
     - React-Core (= 0.61.5)
     - React-CoreModules (= 0.61.5)
     - React-RCTImage (= 0.61.5)
@@ -253,7 +253,7 @@ PODS:
     - React-Core
   - RNSVG (9.13.6-gb):
     - React-Core
-  - RNTAztecView (1.49.0):
+  - RNTAztecView (1.50.0):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.4)
   - WordPress-Aztec-iOS (1.19.4)
@@ -402,7 +402,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 118d0d177724c2d67f08a59136eb29ef5943ec75
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  Gutenberg: a6a27f9f3b421da20f0ea091da6779f3ec036696
+  Gutenberg: 3fb0791ec50a4bfb82d53ee47d57b413229d3a97
   RCTRequired: b153add4da6e7dbc44aebf93f3cf4fcae392ddf1
   RCTTypeSafety: 9aa1b91d7f9310fc6eadc3cf95126ffe818af320
   React: b6a59ef847b2b40bb6e0180a97d0ca716969ac78
@@ -435,7 +435,7 @@ SPEC CHECKSUMS:
   RNReanimated: f05baf4cd76b6eab2e4d7e2b244424960b968918
   RNScreens: 953633729a42e23ad0c93574d676b361e3335e8b
   RNSVG: 46c4b680fe18237fa01eb7d7b311d77618fde31f
-  RNTAztecView: 9fa0a3430874ae395e3e3efa728919c749d6bf9e
+  RNTAztecView: 7552d3a49d7958b422dc089ae5e1d91b8300f58d
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b
 

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-editor",
-	"version": "1.49.0",
+	"version": "1.50.0",
 	"description": "Mobile WordPress gutenberg editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-editor",
-	"version": "1.50.1",
+	"version": "1.51.0",
 	"description": "Mobile WordPress gutenberg editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-editor",
-	"version": "1.50.0",
+	"version": "1.50.1",
 	"description": "Mobile WordPress gutenberg editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Description
Release 1.51.0 of the react-native-editor and Gutenberg-Mobile.

For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/enejb/gutenberg-mobile/pull/2

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->